### PR TITLE
fix HUD rendering in debug mode

### DIFF
--- a/src/main/java/me/alpha432/oyvey/mixin/render/gui/MixinGui.java
+++ b/src/main/java/me/alpha432/oyvey/mixin/render/gui/MixinGui.java
@@ -17,8 +17,6 @@ public class MixinGui {
 
     @Inject(method = "render", at = @At("RETURN"))
     public void render(GuiGraphics context, DeltaTracker tickCounter, CallbackInfo ci) {
-        if (Minecraft.getInstance().gui.getDebugOverlay().showDebugScreen()) return;
-
         Render2DEvent event = new Render2DEvent(context, tickCounter.getGameTimeDeltaPartialTick(true));
         EVENT_BUS.post(event);
     }

--- a/src/main/java/me/alpha432/oyvey/mixin/render/gui/MixinGui.java
+++ b/src/main/java/me/alpha432/oyvey/mixin/render/gui/MixinGui.java
@@ -11,12 +11,17 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import static me.alpha432.oyvey.util.traits.Util.EVENT_BUS;
+import static me.alpha432.oyvey.util.traits.Util.mc;
 
 @Mixin(Gui.class)
 public class MixinGui {
 
     @Inject(method = "render", at = @At("RETURN"))
     public void render(GuiGraphics context, DeltaTracker tickCounter, CallbackInfo ci) {
+        boolean debugOpen = mc.debugEntries.isOverlayVisible();
+
+        if (debugOpen) return;
+
         Render2DEvent event = new Render2DEvent(context, tickCounter.getGameTimeDeltaPartialTick(true));
         EVENT_BUS.post(event);
     }


### PR DESCRIPTION
HUD modules now properly render even when debug overlays are active

Example:
f3 + g (chunk borders) no longer hides HUD elements
HUD visible while debug overlays are active